### PR TITLE
Issue #19 - Fix undefined `legacyResistance2Power` function

### DIFF
--- a/pythoncode/usbTrainer.py
+++ b/pythoncode/usbTrainer.py
@@ -824,7 +824,7 @@ def ReceiveFromTrainer(devTrainer):
         Buttons             = ((tuple[nStatusAndCursors] & 0xf0) >> 4) ^ 0x0f
         Axis                = tuple[nAxis1]
 
-        CurrentPower        = legacyResistance2Power(CurrentResistance, WheelSpeed)
+        CurrentPower        = Resistance2Power(CurrentResistance, WheelSpeed)
 
         if debug.on(debug.Data2):
           logfile.Write ("ReceiveFromTrainer: hr=%s sp=%s CurrentResistance=%s pe=%s cad=%s axis=%s %s %s %s" % \


### PR DESCRIPTION
Fixes #19

Rename `legacyResistance2Power` into `legacyResistance2Power` that supports both new and legacy protocols.