### PR TITLE
Remove wrong dependency

### DIFF
--- a/pythoncode/requirements.txt
+++ b/pythoncode/requirements.txt
@@ -2,6 +2,5 @@ keyboard
 pyusb
 pygame
 pynput
-usb
 wxPython
 wheel


### PR DESCRIPTION
the `usb` dependency does not exist.
Only `pyusb` is required for usb communication.