### PR TITLE
Migrate from master/slave vocabulary

### DIFF
--- a/pythoncode/ExplorAnt.py
+++ b/pythoncode/ExplorAnt.py
@@ -107,7 +107,7 @@ if AntDongle.OK and not clv.SimulateTrainer:
     #---------------------------------------------------------------------------
     # We are going to look what MASTER devices there are
     #---------------------------------------------------------------------------
-    logfile.Console ("ExplorANT: We're in slave mode, listening to master ANT+ devices")
+    logfile.Console ("ExplorANT: We're in subordinate mode, listening to main ANT+ devices")
 
     #---------------------------------------------------------------------------
     # Initialize dongle
@@ -115,18 +115,18 @@ if AntDongle.OK and not clv.SimulateTrainer:
     AntDongle.Calibrate()                          # calibrate ANT+ dongle
 
     #---------------------------------------------------------------------------
-    # Create ANT+ slave channels for pairing to a master device (HRM, FE, ...)
+    # Create ANT+ subordinate channels for pairing to a main device (HRM, FE, ...)
     #
-    # A channel with a wild-card is established when a master-device found.
+    # A channel with a wild-card is established when a main-device found.
     # After that moment, no other device will be seen on that channel.
     #
-    # If ant.SlaveHRM_ChannelConfig(0) is used, the first HRM will
+    # If ant.SubordinateHRM_ChannelConfig(0) is used, the first HRM will
     # be found and not a list of HRM's.
     #
     # Therefore, open as many channels as devices you want to find.
     #
-    # There may be masters around with the pairing bit set and they will be
-    # found only when the slave has the pairing bit set as well
+    # There may be mains around with the pairing bit set and they will be
+    # found only when the subordinate has the pairing bit set as well
     #
     # Therefore set the pairing bit on every odd channel...
     #
@@ -138,15 +138,15 @@ if AntDongle.OK and not clv.SimulateTrainer:
     for i in range(0, NrDevicesToPair):
         print (i, end=' ')
         if i == ant.channel_VTX_s:
-            AntDongle.SlaveVTX_ChannelConfig(0)
+            AntDongle.SubordinateVTX_ChannelConfig(0)
         elif i == ant.channel_VHU_s:
-            AntDongle.SlaveVHU_ChannelConfig(0)
+            AntDongle.SubordinateVHU_ChannelConfig(0)
         else:
             DeviceNumber    =0
             DeviceTypeID    =0
             TransmissionType=0
             if i % 1 == 1: DeviceTypeID &= 0x80
-            AntDongle.SlavePair_ChannelConfig(i, DeviceNumber, DeviceTypeID, TransmissionType)
+            AntDongle.SubordinatePair_ChannelConfig(i, DeviceNumber, DeviceTypeID, TransmissionType)
     print ('')
 
     deviceIDs = []
@@ -178,7 +178,7 @@ if AntDongle.OK and not clv.SimulateTrainer:
             #-------------------------------------------------------------------
             # Only handle ChannelID messages and ignore everyting else
             #
-            # After msgID_ChannelID is received, the master-messages will be
+            # After msgID_ChannelID is received, the main-messages will be
             # received, but we ignore them here because we want to pair only.
             #-------------------------------------------------------------------
             Unknown = True
@@ -193,13 +193,13 @@ if AntDongle.OK and not clv.SimulateTrainer:
                     Unknown = False
 
                 #---------------------------------------------------------------
-                # Message BroadcastData, provides a datapage from master
+                # Message BroadcastData, provides a datapage from main
                 #---------------------------------------------------------------
                 elif id == ant.msgID_BroadcastData:
                     Unknown = False
 
                 #---------------------------------------------------------------
-                # ChannelID - the info from a Master device on the network
+                # ChannelID - the info from a Main device on the network
                 #---------------------------------------------------------------
                 elif id == ant.msgID_ChannelID:
                     Unknown = False
@@ -324,42 +324,42 @@ while AntDongle.OK:
             #-----------------------------------------------------------------------
             # We are going to simulate MASTER devices
             #-----------------------------------------------------------------------
-            logfile.Console ("ExplorANT: We're simulating master ANT+ devices")
+            logfile.Console ("ExplorANT: We're simulating main ANT+ devices")
 
             if clv.hrm >= 0:
                 hrm.Initialize()
                 AntDongle.HRM_ChannelConfig()
-                logfile.Console ('HRM master channel %s opened; device %s (act as an HRM)' % (ant.channel_HRM, ant.DeviceNumber_HRM))
+                logfile.Console ('HRM main channel %s opened; device %s (act as an HRM)' % (ant.channel_HRM, ant.DeviceNumber_HRM))
 
             if clv.fe  >= 0:
                 fe.Initialize()
                 AntDongle.Trainer_ChannelConfig()
-                logfile.Console ('FE  master channel %s opened; device %s (act as a Tacx Trainer)' % (ant.channel_FE, ant.DeviceNumber_FE))
+                logfile.Console ('FE  main channel %s opened; device %s (act as a Tacx Trainer)' % (ant.channel_FE, ant.DeviceNumber_FE))
 
             if clv.vtx >= 0:
                 AntDongle.VTX_ChannelConfig()
-                logfile.Console ('VTX master channel %s opened; device %s (act as a Tacx -Vortex)' % (ant.channel_VTX, ant.DeviceNumber_VTX))
+                logfile.Console ('VTX main channel %s opened; device %s (act as a Tacx -Vortex)' % (ant.channel_VTX, ant.DeviceNumber_VTX))
 
         else:
             if clv.hrm > 0:
-                AntDongle.SlaveHRM_ChannelConfig(clv.hrm)
-                logfile.Console ('HRM slave channel %s opened; listening to master device %s' % (ant.channel_HRM_s, clv.hrm))
+                AntDongle.SubordinateHRM_ChannelConfig(clv.hrm)
+                logfile.Console ('HRM subordinate channel %s opened; listening to main device %s' % (ant.channel_HRM_s, clv.hrm))
 
             if clv.fe  > 0:
-                AntDongle.SlaveTrainer_ChannelConfig(clv.fe)
-                logfile.Console ('FE  slave channel %s opened; listening to master device %s' % (ant.channel_FE_s,  clv.fe))
+                AntDongle.SubordinateTrainer_ChannelConfig(clv.fe)
+                logfile.Console ('FE  subordinate channel %s opened; listening to main device %s' % (ant.channel_FE_s,  clv.fe))
 
             if clv.scs > 0:
-                AntDongle.SlaveSCS_ChannelConfig(clv.scs)
-                logfile.Console ('SCS slave channel %s opened; listening to master device %s' % (ant.channel_SCS_s,  clv.scs))
+                AntDongle.SubordinateSCS_ChannelConfig(clv.scs)
+                logfile.Console ('SCS subordinate channel %s opened; listening to main device %s' % (ant.channel_SCS_s,  clv.scs))
 
             if clv.vtx > 0:
-                AntDongle.SlaveVTX_ChannelConfig(clv.vtx)
-                logfile.Console ('VTX slave channel %s opened; listening to master device %s' % (ant.channel_VTX_s, 0))
+                AntDongle.SubordinateVTX_ChannelConfig(clv.vtx)
+                logfile.Console ('VTX subordinate channel %s opened; listening to main device %s' % (ant.channel_VTX_s, 0))
 
             if clv.vhu > 0:
-                AntDongle.SlaveVHU_ChannelConfig(clv.vhu)
-                logfile.Console ('VHU slave channel %s opened; listening to master device %s' % (ant.channel_VHU_s, 0))
+                AntDongle.SubordinateVHU_ChannelConfig(clv.vhu)
+                logfile.Console ('VHU subordinate channel %s opened; listening to main device %s' % (ant.channel_VHU_s, 0))
 
         # ----------------------------------------------------------------------
         # Get info from the devices
@@ -408,7 +408,7 @@ while AntDongle.OK:
             while RunningSwitch == True and not AntDongle.DongleReconnected:
                 StartTime = time.time()
                 #---------------------------------------------------------------
-                # Simulate HRM, FE-S, VTX (master device, broadcasting data)
+                # Simulate HRM, FE-S, VTX (main device, broadcasting data)
                 #---------------------------------------------------------------
                 messages     = []
 
@@ -479,12 +479,12 @@ while AntDongle.OK:
                         Unknown = False
 
                     #-----------------------------------------------------------
-                    # Message BroadcastData, provides a datapage from master
+                    # Message BroadcastData, provides a datapage from main
                     #-----------------------------------------------------------
                     elif id == ant.msgID_BroadcastData:
                         #-------------------------------------------------------
                         # HRM_s = Heart rate Monitor Display
-                        # We are slave, listening to a master (Heartrate belt)
+                        # We are subordinate, listening to a main (Heartrate belt)
                         #-------------------------------------------------------
                         if Channel == ant.channel_HRM_s:
                             HRM_s_count += 1
@@ -522,7 +522,7 @@ while AntDongle.OK:
 
                         #-------------------------------------------------------
                         # FE_s = Cycle Training Program (e.g. Zwift, Trainer Road)
-                        # We are slave, listening to a master Tacx Trainer
+                        # We are subordinate, listening to a main Tacx Trainer
                         #-------------------------------------------------------
                         elif Channel == ant.channel_FE_s:
                             FE_s_count += 1
@@ -572,7 +572,7 @@ while AntDongle.OK:
 
                         #-------------------------------------------------------
                         # SCS_s = Heart rate Monitor Display
-                        # We are slave, listening to a master (Speed Cadence Sensor)
+                        # We are subordinate, listening to a main (Speed Cadence Sensor)
                         #-------------------------------------------------------
                         if Channel == ant.channel_SCS_s:
                             SCS_s_count += 1
@@ -607,7 +607,7 @@ while AntDongle.OK:
 
                         #-------------------------------------------------------
                         # VTX_s = Tacx i-Vortex trainer
-                        # We are slave, listening to a master (the real trainer)
+                        # We are subordinate, listening to a main (the real trainer)
                         #-------------------------------------------------------
                         elif Channel == ant.channel_VTX_s:
                             #---------------------------------------------------
@@ -650,7 +650,7 @@ while AntDongle.OK:
 
                         #-------------------------------------------------------
                         # VTX = Cycle Training Program (e.g. Zwift, Trainer Road)
-                        # We are slave, listening to a master Fortius ANT or TTS
+                        # We are subordinate, listening to a main Fortius ANT or TTS
                         #
                         #-------------------------------------------------------
                         elif Channel == ant.channel_VTX:
@@ -692,7 +692,7 @@ while AntDongle.OK:
                             #-------------------------------------------------------
                             elif DataPageNumber == 70:
                                 dpRequestDatapage += 1
-                                SlaveSerialNumber, DescriptorByte1, DescriptorByte2, AckRequired, NrTimes, \
+                                SubordinateSerialNumber, DescriptorByte1, DescriptorByte2, AckRequired, NrTimes, \
                                     RequestedPageNumber, CommandType = ant.msgUnpage70_RequestDataPage(info)
 
                                 info = False

--- a/pythoncode/ExplorAntCommand.py
+++ b/pythoncode/ExplorAntCommand.py
@@ -40,7 +40,7 @@ class CommandLineVariables(object):
         parser = argparse.ArgumentParser(description='Program to explore ANT devices in the system')
         parser.add_argument('-a','--autostart', help='Automatically start',                 required=False, action='store_true')
         parser.add_argument('-d','--debug',     help='Show debugging data',                 required=False, default=False)
-        parser.add_argument('-s','--simulate',  help='Simulate master HRM and FE-C',        required=False, action='store_true')
+        parser.add_argument('-s','--simulate',  help='Simulate main HRM and FE-C',        required=False, action='store_true')
         parser.add_argument('-D','--dongle',    help='Use this ANT dongle',                 required=False, default=False)
         parser.add_argument('-H','--hrm',       help='Pair with this Heart Rate Monitor',   required=False, default=False)
         parser.add_argument('-F','--fe',        help='Pair with this Fitness Equipment',    required=False, default=False)

--- a/pythoncode/FortiusAntBody.py
+++ b/pythoncode/FortiusAntBody.py
@@ -3,8 +3,8 @@
 #-------------------------------------------------------------------------------
 __version__ = "2020-06-12"
 # 2020-06-12    Added: BikePowerProfile and SpeedAndCadenceSensor final
-# 2020-06-11    Added: BikePowerProfile (master)
-# 2020-06-09    Added: SpeedAndCadenceSensor (master)
+# 2020-06-11    Added: BikePowerProfile (main)
+# 2020-06-09    Added: SpeedAndCadenceSensor (main)
 # 2020-05-27    Added: msgPage71_CommandStatus handled -- and tested
 # 2020-05-24    i-Vortex adjustments
 #               - in manual mode, ANTdongle must be present as well, so that
@@ -484,11 +484,11 @@ def Tacx2DongleSub(self, Restart):
     p71_Data4                   = 0xff
 
     #---------------------------------------------------------------------------
-    # Info from ANT slave channels
+    # Info from ANT subordinate channels
     #---------------------------------------------------------------------------
     HeartRate       = 0         # This field is displayed
                                 # We have two sources: the trainer or
-                                # our own HRM slave channel.
+                                # our own HRM subordinate channel.
     #Cadence        = 0         # Analogously for Speed Cadence Sensor
                                 # But is not yet implemented
     #---------------------------------------------------------------------------
@@ -509,17 +509,17 @@ def Tacx2DongleSub(self, Restart):
     #---------------------------------------------------------------------------
     AntDongle.ResetDongle()             # reset dongle
     AntDongle.Calibrate()               # calibrate ANT+ dongle
-    AntDongle.Trainer_ChannelConfig()   # Create ANT+ master channel for FE-C
+    AntDongle.Trainer_ChannelConfig()   # Create ANT+ main channel for FE-C
     
     if clv.hrm == None:
-        AntDongle.HRM_ChannelConfig()   # Create ANT+ master channel for HRM
+        AntDongle.HRM_ChannelConfig()   # Create ANT+ main channel for HRM
     elif clv.hrm < 0:
         pass                            # No Heartrate at all
     else:
         #-------------------------------------------------------------------
-        # Create ANT+ slave channel for HRM;   0: auto pair, nnn: defined HRM
+        # Create ANT+ subordinate channel for HRM;   0: auto pair, nnn: defined HRM
         #-------------------------------------------------------------------
-        AntDongle.SlaveHRM_ChannelConfig(clv.hrm)
+        AntDongle.SubordinateHRM_ChannelConfig(clv.hrm)
 
         #-------------------------------------------------------------------
         # Request what DeviceID is paired to the HRM-channel
@@ -530,42 +530,42 @@ def Tacx2DongleSub(self, Restart):
 
     if clv.Tacx_iVortex:
         #-------------------------------------------------------------------
-        # Create ANT+ slave channel for VTX
+        # Create ANT+ subordinate channel for VTX
         # No pairing-loop: VTX perhaps not yet active and avoid delay
         #-------------------------------------------------------------------
-        AntDongle.SlaveVTX_ChannelConfig(0)
+        AntDongle.SubordinateVTX_ChannelConfig(0)
 
         # msg = ant.msg4D_RequestMessage(ant.channel_VTX_s, ant.msgID_ChannelID)
         # AntDongle.Write([msg], False, False)
 
         #-------------------------------------------------------------------
-        # Create ANT+ slave channel for VHU
+        # Create ANT+ subordinate channel for VHU
         #
         # We create this channel right away. At some stage the VTX-channel
         # sends the Page03_TacxVortexDataCalibration which provides the
         # VortexID. This VortexID is the DeviceID that could be provided
-        # to SlaveVHU_ChannelConfig() to restrict pairing to that headunit
+        # to SubordinateVHU_ChannelConfig() to restrict pairing to that headunit
         # only. Not relevant in private environments, so left as is here.
         #-------------------------------------------------------------------
-        AntDongle.SlaveVHU_ChannelConfig(0)
+        AntDongle.SubordinateVHU_ChannelConfig(0)
 
     if True:
         #-------------------------------------------------------------------
-        # Create ANT+ master channel for PWR
+        # Create ANT+ main channel for PWR
         #-------------------------------------------------------------------
         AntDongle.PWR_ChannelConfig(ant.channel_PWR)
 
     if clv.scs == None:
         #-------------------------------------------------------------------
-        # Create ANT+ master channel for SCS
+        # Create ANT+ main channel for SCS
         #-------------------------------------------------------------------
         AntDongle.SCS_ChannelConfig(ant.channel_SCS)
     else:
         #-------------------------------------------------------------------
-        # Create ANT+ slave channel for SCS
+        # Create ANT+ subordinate channel for SCS
         # 0: auto pair, nnn: defined SCS
         #-------------------------------------------------------------------
-        AntDongle.SlaveSCS_ChannelConfig(clv.scs)
+        AntDongle.SubordinateSCS_ChannelConfig(clv.scs)
         pass
     
     if not clv.gui: logfile.Console ("Ctrl-C to exit")
@@ -863,7 +863,7 @@ def Tacx2DongleSub(self, Restart):
                     pass                    # Message is handled or ignored
 
                 #---------------------------------------------------------------
-                # AcknowledgedData = Slave -> Master
+                # AcknowledgedData = Subordinate -> Main
                 #       channel_FE = From CTP (Trainer Road, Zwift) --> Tacx 
                 #---------------------------------------------------------------
                 elif id == ant.msgID_AcknowledgedData:
@@ -964,7 +964,7 @@ def Tacx2DongleSub(self, Restart):
                         # Data page 70 Request data page
                         #-------------------------------------------------------
                         elif DataPageNumber == 70:
-                            _SlaveSerialNumber, _DescriptorByte1, _DescriptorByte2, \
+                            _SubordinateSerialNumber, _DescriptorByte1, _DescriptorByte2, \
                                 _AckRequired, NrTimes, RequestedPageNumber, \
                                 _CommandType = ant.msgUnpage70_RequestDataPage(info)
                             
@@ -1020,7 +1020,7 @@ def Tacx2DongleSub(self, Restart):
                     else: error="Unknown channel"
 
                 #---------------------------------------------------------------
-                # BroadcastData = Master -> Slave
+                # BroadcastData = Main -> Subordinate
                 #       channel_HRM_s = Heartbeat received from HRM
                 #       channel_SCS_s = Speed/Cadence received from SCS
                 #---------------------------------------------------------------
@@ -1091,7 +1091,7 @@ def Tacx2DongleSub(self, Restart):
                     else: error = "Unknown channel"
 
                 #---------------------------------------------------------------
-                # ChannelID - the info that a master on the network is paired
+                # ChannelID - the info that a main on the network is paired
                 #---------------------------------------------------------------
                 elif id == ant.msgID_ChannelID:
                     Channel, DeviceNumber, DeviceTypeID, _TransmissionType = \

--- a/pythoncode/FortiusAntCommand.py
+++ b/pythoncode/FortiusAntCommand.py
@@ -210,8 +210,8 @@ class CommandLineVariables(object):
 
         #-----------------------------------------------------------------------
         # Get HRM
-        # - None: read HRM from Tacx Fortius and broadcast as HRM master device
-        # - -1  : no master and no slave device
+        # - None: read HRM from Tacx Fortius and broadcast as HRM main device
+        # - -1  : no main and no subordinate device
         # - 0   : pair with the first ANT+ HRM that is found
         # - next: pair with the defined ANT+ HRM monitor
         #             the number can be found with ExplorANT

--- a/pythoncode/antDongle.py
+++ b/pythoncode/antDongle.py
@@ -2,7 +2,7 @@
 # Version info
 #---------------------------------------------------------------------------
 __version__ = "2020-06-16"
-# 2020-06-16    Added: When pairing with a master, the master-id is printed
+# 2020-06-16    Added: When pairing with a main, the main-id is printed
 # 2020-06-12    Added: BikePowerProfile and SpeedAndCadenceSensor final
 # 2020-06-10    Changed: ChannelPeriods defined decimal, like ANT+ specification
 # 2020-06-09    Added: SpeedAndCadenceSensor 
@@ -15,7 +15,7 @@ __version__ = "2020-06-16"
 # 2020-05-14    Added: msgPage000_TacxVortexHU_NoPowerOff
 #                      msgPage172_TacxVortexHU_ChangeHeadunitMode
 #                      msgUnpage221_TacxVortexHU_ButtonPressed
-#               Changed: msgID_ChannelID issued in SlaveXXX_ChannelConfig
+#               Changed: msgID_ChannelID issued in SubordinateXXX_ChannelConfig
 # 2020-05-13    Added:    msgUnpage50_WindResistance
 #               Modified: msgUnpage51_TrackResistance
 #               #55 Support for Data Page 50 - Wind Resistance
@@ -23,7 +23,7 @@ __version__ = "2020-06-16"
 # 2020-05-08    Linux: detach_kernel_driver added 
 # 2020-05-07    clsAntDongle encapsulates all functions
 # 2020-05-07    pylint error free
-# 2020-05-01    Added: SlaveVHU_ChannelConfig()
+# 2020-05-01    Added: SubordinateVHU_ChannelConfig()
 #               Disabled: SCS because of lack of channel numbers
 # 2020-04-29    msgUnpage00_TacxVortexDataSpeed, speed corrected (0x03ff)
 # 2020-04-28    crash when checksum incorrect; conditions were in wrong sequence
@@ -67,7 +67,7 @@ __version__ = "2020-06-16"
 #               Calibrate() changed with respect to reset-dongle
 # 2020-02-10    SCS added (example code, not tested)
 # 2020-02-02    Function EnumerateAll() added, GetDongle() has optional input
-#               Function SlaveTrainer_ChannelConfig(), SlaveHRM_ChannelConfig()
+#               Function SubordinateTrainer_ChannelConfig(), SubordinateHRM_ChannelConfig()
 #                   for device pairing, with related constants
 #               Improved logging, major overhaul
 # 2020-01-23    OS-dependant code seems unnecessary; disabled
@@ -95,27 +95,27 @@ import FortiusAntCommand    as cmd
 #---------------------------------------------------------------------------
 # Our own choice what channels are used
 #
-# Note that a running program cannot be slave AND master for same device
+# Note that a running program cannot be subordinate AND main for same device
 # since the channels are statically assigned!
 #---------------------------------------------------------------------------
 # M A X #   c h a n n e l s   m a y   b e   8   s o   b e w a r e   h e r e !
 #---------------------------------------------------------------------------
 channel_FE          = 0           # ANT+ channel for Fitness Equipment
-channel_FE_s        = channel_FE  # slave=Cycle Training Program
+channel_FE_s        = channel_FE  # subordinate=Cycle Training Program
 
 channel_HRM         = 1           # ANT+ channel for Heart Rate Monitor
-channel_HRM_s       = channel_HRM # slave=display or Cycle Training Program
+channel_HRM_s       = channel_HRM # subordinate=display or Cycle Training Program
 
 channel_PWR         = 2           # ANT+ Channel for Power Profile
 
 channel_SCS         = 3           # ANT+ Channel for Speed Cadence Sensor
-channel_SCS_s       = channel_SCS # slave=display or Cycle Training Program
+channel_SCS_s       = channel_SCS # subordinate=display or Cycle Training Program
 
 channel_VTX         = 4           # ANT+ Channel for Tacx i-Vortex
-channel_VTX_s       = channel_VTX # slave=Cycle Training Program
+channel_VTX_s       = channel_VTX # subordinate=Cycle Training Program
 
 channel_VHU_s       = 5           # ANT+ Channel for Tacx i-Vortex Headunit
-                                  # slave=Cycle Training Program
+                                  # subordinate=Cycle Training Program
 
 #---------------------------------------------------------------------------
 # i-Vortex Headunit modes
@@ -123,12 +123,12 @@ channel_VHU_s       = 5           # ANT+ Channel for Tacx i-Vortex Headunit
 VHU_Normal          = 0        # Headunit commands the i-Vortex trainer
 VHU_SpecialMode     = 2        # Headunit controls the i-Vortex and 
                                #        FortiusANT TargetPower seems ignored.
-VHU_PCmode          = 4        # Headunit only sends buttons to slave (FortiusANT)
+VHU_PCmode          = 4        # Headunit only sends buttons to subordinate (FortiusANT)
 
 
-DeviceNumber_EA     = 57590    # short Slave device-number for ExplorANT
+DeviceNumber_EA     = 57590    # short Subordinate device-number for ExplorANT
 DeviceNumber_FE     = 57591    #       These are the device-numbers FortiusANT uses and
-DeviceNumber_HRM    = 57592    #       slaves (TrainerRoad, Zwift, ExplorANT) will find.
+DeviceNumber_HRM    = 57592    #       subordinates (TrainerRoad, Zwift, ExplorANT) will find.
 DeviceNumber_VTX    = 57593    #
 DeviceNumber_VHU    = 57594    #
 DeviceNumber_SCS    = 57595    #
@@ -160,17 +160,17 @@ if False:                      # Tacx Neo Erik OT; perhaps relevant for Tacx Des
 #---------------------------------------------------------------------------
 # D00000652_ANT_Message_Protocol_and_Usage_Rev_5.1.pdf
 # 5.2.1 Channel Type
-# 5.3   Establishing a channel (defines master/slave)
+# 5.3   Establishing a channel (defines main/subordinate)
 # 9.3   ANT Message summary
 #---------------------------------------------------------------------------
-ChannelType_BidirectionalReceive        = 0x00          # Slave
-ChannelType_BidirectionalTransmit       = 0x10          # Master
+ChannelType_BidirectionalReceive        = 0x00          # Subordinate
+ChannelType_BidirectionalTransmit       = 0x10          # Main
 
-ChannelType_UnidirectionalReceiveOnly   = 0x40          # Slave
-ChannelType_UnidirectionalTransmitOnly  = 0x50          # Master
+ChannelType_UnidirectionalReceiveOnly   = 0x40          # Subordinate
+ChannelType_UnidirectionalTransmitOnly  = 0x50          # Main
 
-ChannelType_SharedBidirectionalReceive  = 0x20          # Slave
-ChannelType_SharedBidirectionalTransmit = 0x30          # Master
+ChannelType_SharedBidirectionalReceive  = 0x20          # Subordinate
+ChannelType_SharedBidirectionalTransmit = 0x30          # Main
 
 msgID_RF_EVENT                          = 0x01
 
@@ -189,7 +189,7 @@ msgID_ResetSystem                       = 0x4a
 msgID_OpenChannel                       = 0x4b
 msgID_RequestMessage                    = 0x4d
 
-msgID_ChannelID                         = 0x51          # Set, but also receive master channel - but how/when?
+msgID_ChannelID                         = 0x51          # Set, but also receive main channel - but how/when?
 msgID_ChannelTransmitPower              = 0x60
 
 msgID_StartUp                           = 0x6f
@@ -626,13 +626,13 @@ class clsAntDongle():
             self.Write(messages, False)
         time.sleep(0.500)                           # After Reset, 500ms before next action
 
-    def SlavePair_ChannelConfig(self, channel_pair, \
+    def SubordinatePair_ChannelConfig(self, channel_pair, \
                                 DeviceNumber=0, DeviceTypeID=0, TransmissionType=0):
-                                # Slave, by default full wildcards ChannelID, see msg51 comment
+                                # Subordinate, by default full wildcards ChannelID, see msg51 comment
         if DeviceNumber > 0: s = ", id=%s only" % DeviceNumber
         else:                s = ", any device"
         logfile.Console ('FortiusANT tries to pair with an ANT+ device' + s)
-        if debug.on(debug.Data1): logfile.Write ("SlavePair_ChannelConfig()")
+        if debug.on(debug.Data1): logfile.Write ("SubordinatePair_ChannelConfig()")
         messages=[
             msg42_AssignChannel         (channel_pair, ChannelType_BidirectionalReceive, NetworkNumber=0x00),
             msg51_ChannelID             (channel_pair, DeviceNumber, DeviceTypeID, TransmissionType),
@@ -656,11 +656,11 @@ class clsAntDongle():
         ]
         self.Write(messages)
 
-    def SlaveTrainer_ChannelConfig(self, DeviceNumber):
+    def SubordinateTrainer_ChannelConfig(self, DeviceNumber):
         if DeviceNumber > 0: s = ", id=%s only" % DeviceNumber
         else:                s = ", any device"
         logfile.Console ('FortiusANT receives data from an ANT+ Controlled Fitness Equipent device (FE-C)' + s)
-        if debug.on(debug.Data1): logfile.Write ("SlaveTrainer_ChannelConfig()")
+        if debug.on(debug.Data1): logfile.Write ("SubordinateTrainer_ChannelConfig()")
         messages=[
             msg42_AssignChannel         (channel_FE_s, ChannelType_BidirectionalReceive, NetworkNumber=0x00),
             msg51_ChannelID             (channel_FE_s, DeviceNumber, DeviceTypeID_FE, TransmissionType_IC_GDP),
@@ -685,11 +685,11 @@ class clsAntDongle():
         ]
         self.Write(messages)
 
-    def SlaveHRM_ChannelConfig(self, DeviceNumber):
+    def SubordinateHRM_ChannelConfig(self, DeviceNumber):
         if DeviceNumber > 0: s = ", id=%s only" % DeviceNumber
         else:                s = ", any device"
         logfile.Console ('FortiusANT receives data from an ANT+ Heart Rate Monitor (HRM display)' + s)
-        if debug.on(debug.Data1): logfile.Write ("SlaveHRM_ChannelConfig()")
+        if debug.on(debug.Data1): logfile.Write ("SubordinateHRM_ChannelConfig()")
         messages=[
             msg42_AssignChannel         (channel_HRM_s, ChannelType_BidirectionalReceive, NetworkNumber=0x00),
             msg51_ChannelID             (channel_HRM_s, DeviceNumber, DeviceTypeID_HRM, TransmissionType_IC),
@@ -727,11 +727,11 @@ class clsAntDongle():
         ]
         self.Write(messages)
 
-    def SlaveSCS_ChannelConfig(self, DeviceNumber):
+    def SubordinateSCS_ChannelConfig(self, DeviceNumber):
         if DeviceNumber > 0: s = ", id=%s only" % DeviceNumber
         else:                s = ", any device"
         logfile.Console ('FortiusANT receives data from an ANT+ Speed and Cadence Sensor (SCS Display)' + s)
-        if debug.on(debug.Data1): logfile.Write ("SlaveSCS_ChannelConfig()")
+        if debug.on(debug.Data1): logfile.Write ("SubordinateSCS_ChannelConfig()")
         messages=[
             msg42_AssignChannel         (channel_SCS_s, ChannelType_BidirectionalReceive, NetworkNumber=0x00),
             msg51_ChannelID             (channel_SCS_s, DeviceNumber, DeviceTypeID_SCS, TransmissionType_IC),
@@ -757,11 +757,11 @@ class clsAntDongle():
         ]
         self.Write(messages)
 
-    def SlaveVTX_ChannelConfig(self, DeviceNumber):     # Listen to a Tacx i-Vortex
+    def SubordinateVTX_ChannelConfig(self, DeviceNumber):     # Listen to a Tacx i-Vortex
         if DeviceNumber > 0: s = ", id=%s only" % DeviceNumber
         else:                s = ", any device"
         logfile.Console ('FortiusANT receives data from an ANT+ Tacx i-Vortex (VTX Controller)' + s)
-        if debug.on(debug.Data1): logfile.Write ("SlaveVTX_ChannelConfig()")
+        if debug.on(debug.Data1): logfile.Write ("SubordinateVTX_ChannelConfig()")
         messages=[
             msg42_AssignChannel         (channel_VTX_s, ChannelType_BidirectionalReceive, NetworkNumber=0x01),
             msg51_ChannelID             (channel_VTX_s, DeviceNumber, DeviceTypeID_VTX, TransmissionType_IC),
@@ -773,13 +773,13 @@ class clsAntDongle():
         ]
         self.Write(messages)
 
-    def SlaveVHU_ChannelConfig(self, DeviceNumber):     # Listen to a Tacx i-Vortex Headunit
+    def SubordinateVHU_ChannelConfig(self, DeviceNumber):     # Listen to a Tacx i-Vortex Headunit
                                                         # See comment above msgPage000_TacxVortexHU_StayAlive
         
         if DeviceNumber > 0: s = ", id=%s only" % DeviceNumber
         else:                s = ", any device"
         logfile.Console ('FortiusANT receives data from an ANT+ Tacx i-Vortex Headunit (VHU Controller)' + s)
-        if debug.on(debug.Data1): logfile.Write ("SlaveVHU_ChannelConfig()")
+        if debug.on(debug.Data1): logfile.Write ("SubordinateVHU_ChannelConfig()")
         messages=[
             msg42_AssignChannel         (channel_VHU_s, ChannelType_BidirectionalReceive, NetworkNumber=0x01),
             msg51_ChannelID             (channel_VHU_s, DeviceNumber, DeviceTypeID_VHU, TransmissionType_IC),
@@ -1898,23 +1898,23 @@ def msgUnpage55_UserConfiguration(info):
 # D00001198_-_ANT+_Common_Data_Pages_Rev_3.1.pdf
 # Common Data Page 70: (0x46) RequestDataPage
 # ------------------------------------------------------------------------------
-def msgPage70_RequestDataPage(Channel, SlaveSerialNumber, DescriptorByte1, \
+def msgPage70_RequestDataPage(Channel, SubordinateSerialNumber, DescriptorByte1, \
                 DescriptorByte2, NrTimes, RequestedPageNumber, CommandType):
     DataPageNumber      = 70
 
     fChannel            = sc.unsigned_char  # First byte of the ANT+ message content
     fDataPageNumber     = sc.unsigned_char  # First byte of the ANT+ datapage (payload)
-    fSlaveSerialNumber  = sc.unsigned_short
+    fSubordinateSerialNumber  = sc.unsigned_short
     fDescriptorByte1    = sc.unsigned_char
     fDescriptorByte2    = sc.unsigned_char
     fReqTransmissionResp= sc.unsigned_char
     fRequestedPageNumber= sc.unsigned_char
     fCommandType        = sc.unsigned_char
 
-    format=    sc.no_alignment + fChannel + fDataPageNumber + fSlaveSerialNumber + fDescriptorByte1 + \
+    format=    sc.no_alignment + fChannel + fDataPageNumber + fSubordinateSerialNumber + fDescriptorByte1 + \
                fDescriptorByte2 + fReqTransmissionResp + fRequestedPageNumber + fCommandType
 
-    info  = struct.pack (format,  Channel,   DataPageNumber,   SlaveSerialNumber,   DescriptorByte1,  \
+    info  = struct.pack (format,  Channel,   DataPageNumber,   SubordinateSerialNumber,   DescriptorByte1,  \
                 DescriptorByte2,   NrTimes,               RequestedPageNumber,   CommandType)
 
     return info
@@ -1926,8 +1926,8 @@ def msgUnpage70_RequestDataPage(info):
     _nDataPageNumber    = 1
     fDataPageNumber     = sc.unsigned_char  # First byte of the ANT+ datapage (payload)
 
-    nSlaveSerialNumber  = 2
-    fSlaveSerialNumber  = sc.unsigned_short
+    nSubordinateSerialNumber  = 2
+    fSubordinateSerialNumber  = sc.unsigned_short
 
     nDescriptorByte1    = 3
     fDescriptorByte1    = sc.unsigned_char
@@ -1944,7 +1944,7 @@ def msgUnpage70_RequestDataPage(info):
     nCommandType        = 7
     fCommandType        = sc.unsigned_char
 
-    format = sc.no_alignment + fChannel + fDataPageNumber + fSlaveSerialNumber + \
+    format = sc.no_alignment + fChannel + fDataPageNumber + fSubordinateSerialNumber + \
              fDescriptorByte1 + fDescriptorByte2 + fReqTransmissionResp + \
              fRequestedPageNumber + fCommandType
     tuple  = struct.unpack (format, info)
@@ -1953,7 +1953,7 @@ def msgUnpage70_RequestDataPage(info):
     AckRequired         = ReqTranmissionResponse & 0x80
     NrTimes             = ReqTranmissionResponse & 0x7f
 
-    return tuple[nSlaveSerialNumber], tuple[nDescriptorByte1], tuple[nDescriptorByte2], \
+    return tuple[nSubordinateSerialNumber], tuple[nDescriptorByte1], tuple[nDescriptorByte2], \
            AckRequired, NrTimes, tuple[nRequestedPageNumber], tuple[nCommandType]
 
 # ------------------------------------------------------------------------------

--- a/pythoncode/usbTrainer.py
+++ b/pythoncode/usbTrainer.py
@@ -950,7 +950,7 @@ class clsTacxAntVortexTrainer(clsTacxTrainer):
                 dataHandled = True
 
             #-------------------------------------------------------------------
-            # BroadcastData - info received from the master device
+            # BroadcastData - info received from the main device
             #-------------------------------------------------------------------
             elif id == ant.msgID_BroadcastData:
                 #---------------------------------------------------------------
@@ -1004,7 +1004,7 @@ class clsTacxAntVortexTrainer(clsTacxTrainer):
                             (DataPageNumber, VTX_Calibration, self.__VortexID))
 
             #-------------------------------------------------------------------
-            # ChannelID - the info that a master on the network is paired
+            # ChannelID - the info that a main on the network is paired
             #-------------------------------------------------------------------
             elif id == ant.msgID_ChannelID:
                 Channel, DeviceNumber, DeviceTypeID, _TransmissionType = \
@@ -1034,7 +1034,7 @@ class clsTacxAntVortexTrainer(clsTacxTrainer):
                               ant.msgUnpage221_TacxVortexHU_ButtonPressed (info)
 
             #-------------------------------------------------------------------
-            # BroadcastData - info received from the master device
+            # BroadcastData - info received from the main device
             #-------------------------------------------------------------------
             elif id == ant.msgID_BroadcastData:
                 #---------------------------------------------------------------
@@ -1051,7 +1051,7 @@ class clsTacxAntVortexTrainer(clsTacxTrainer):
                     dataHandled = True
 
             #-------------------------------------------------------------------
-            # ChannelID - the info that a master on the network is paired
+            # ChannelID - the info that a main on the network is paired
             #-------------------------------------------------------------------
             elif id == ant.msgID_ChannelID:
                 Channel, DeviceNumber, DeviceTypeID, _TransmissionType = \


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.