### PR TITLE
Steering

### DIFF
--- a/node/fitness-machine-service/indoor-bike-data-characteristic.js
+++ b/node/fitness-machine-service/indoor-bike-data-characteristic.js
@@ -81,14 +81,16 @@ class IndoorBikeDataCharacteristic extends  bleno.Characteristic {
     //   offset += 2;
     // }
 
-    // Write the flags
-    flagField.writeUInt16LE(flags);
+    if (flags) {
+      // Write the flags
+      flagField.writeUInt16LE(flags);
 
-    let finalbuffer = buffer.slice(0, offset);
-    debug(finalbuffer);
+      let finalbuffer = buffer.slice(0, offset);
+      debug(finalbuffer);
 
-    if (this.updateValueCallback) {
-      this.updateValueCallback(finalbuffer);
+      if (this.updateValueCallback) {
+        this.updateValueCallback(finalbuffer);
+      }
     }
 
     return this.RESULT_SUCCESS;

--- a/node/server.js
+++ b/node/server.js
@@ -5,7 +5,22 @@ const debug = require('debug');
 const trace = debug('fortiusant:server');
 const version = require('./version');
 
-let trainer = new VirtualTrainer();
+const args = process.argv.slice(2);
+
+args.forEach(function (val, index, array) {
+  trace("args[" + index + '] = ' + val)
+})
+
+if (args[0] == "steering") {
+  var steeringEnabled = true
+}
+else {
+  var steeringEnabled = false
+}
+
+trace("Steering is " + (steeringEnabled ? "enabled" : "disabled"))
+
+let trainer = new VirtualTrainer(steeringEnabled);
 let server = express();
 
 server.use(bodyParser.urlencoded({extended: true}));

--- a/node/steering-service/rx-characteristic.js
+++ b/node/steering-service/rx-characteristic.js
@@ -1,0 +1,76 @@
+
+const bleno = require('bleno');
+const debug = require('debug');
+const trace = debug('fortiusant:rx');
+
+const CharacteristicUserDescription = '2901';
+const UnknownFeature1 = '347b0031-7635-408b-8918-8ff3949ce592';
+
+class RxCharacteristic extends  bleno.Characteristic {
+  constructor(tc) {
+    trace('[RxCharacteristic] constructor');
+    super({
+      uuid: UnknownFeature1,
+      properties: ['write'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Rx'
+        })
+      ],
+    });
+
+    this.tc = tc;
+  }
+
+  onWriteRequest(data, offset, withoutResponse, callback) {
+    trace('[RxCharacteristic] onWriteRequest');
+    trace('data len: ' + data.length);
+
+    if (data.length == 1) {
+      let value = data.readUInt8(0);
+      trace('data: ' + value);
+      callback(this.RESULT_SUCCESS);
+      return;
+    }
+
+    let value = data.readUInt16BE(0);
+    trace('[RxCharacteristic] write ' + value);
+
+    switch(value) {
+      case 0x0310:
+        if (this.tc.indicate) {
+          let buffer = new Buffer.alloc(4);
+          buffer.writeUInt16BE(0x0310, 0);
+          buffer.writeUInt16BE(0x4a89, 2);
+          trace('[RxCharacteristic] Indicating (' + buffer + ') via tx characteristic');
+          this.tc.indicate(buffer);
+        }
+        else {
+          trace('[RxCharacteristic] Cannot indicate, no callback registered');
+        }
+        break;
+      case 0x0311:
+        if (this.tc.indicate) {
+          let buffer = new Buffer.alloc(4);
+          buffer.writeUInt16BE(0x0311, 0);
+          buffer.writeUInt16BE(0xffff, 2);
+          trace('[RxCharacteristic] Indicating (' + buffer + ') via tx characteristic');
+          this.tc.indicate(buffer);
+        }
+        else {
+          trace('[RxCharacteristic] Cannot indicate, no callback registered');
+        }
+        break;
+      case 0x0202:
+        trace('[RxCharacteristic] Received 0x0202');
+      default:
+        trace('[RxCharacteristic] Unknown value: ' + value);
+        break;
+    }
+
+    callback(this.RESULT_SUCCESS);
+  }
+}
+
+module.exports = RxCharacteristic;

--- a/node/steering-service/steering-characteristic.js
+++ b/node/steering-service/steering-characteristic.js
@@ -1,0 +1,52 @@
+const debug = require('debug')('fortiusant:sc');
+const bleno = require('bleno');
+
+const Steering = '347b0030-7635-408b-8918-8ff3949ce592';
+const CharacteristicUserDescription = '2901';
+
+class SteeringCharacteristic extends bleno.Characteristic {
+  constructor() {
+    super({
+      uuid: Steering,
+      properties: ['notify'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Steering Angle'
+        }),
+      ]
+    });
+    this.updateValueCallback = null;  
+  }
+
+  onSubscribe(maxValueSize, updateValueCallback) {
+    debug('[SteeringCharacteristic] onSubscribe');
+    this.updateValueCallback = updateValueCallback;
+    return this.RESULT_SUCCESS;
+  };
+
+  onUnsubscribe() {
+    debug('[SteeringCharacteristic] onUnsubscribe');
+    this.updateValueCallback = null;
+    return this.RESULT_UNLIKELY_ERROR;
+  };
+
+  notify(event) {
+    debug('[SteeringCharacteristic] notify');
+    if ('steering_angle' in event) {
+      let buffer = new Buffer.alloc(4);
+
+      debug('[SteeringCharacteristic] Steering Angle(deg.): ' + event.steering_angle);
+
+      buffer.writeFloatLE(event.steering_angle)
+
+      if (this.updateValueCallback) {
+        this.updateValueCallback(buffer);
+      }
+    }
+
+    return this.RESULT_SUCCESS;
+  }
+};
+
+module.exports = SteeringCharacteristic;

--- a/node/steering-service/steering-service.js
+++ b/node/steering-service/steering-service.js
@@ -1,0 +1,50 @@
+const bleno = require('bleno');
+
+const SteeringCharacteristic = require('./steering-characteristic');
+const RxCharacteristic = require('./rx-characteristic');
+const TxCharacteristic = require('./tx-characteristic');
+const UnknownCharacteristic1 = require('./unknown-characteristic-1');
+const UnknownCharacteristic2 = require('./unknown-characteristic-2');
+const UnknownCharacteristic3 = require('./unknown-characteristic-3');
+const UnknownCharacteristic4 = require('./unknown-characteristic-4');
+
+const Steering = "347b0001-7635-408b-8918-8ff3949ce592";
+
+class SteeringService extends bleno.PrimaryService {
+  constructor() {
+    let uc1 = new UnknownCharacteristic1();
+    let uc2 = new UnknownCharacteristic2();
+    let uc3 = new UnknownCharacteristic3();
+    let uc4 = new UnknownCharacteristic4();
+    let sc = new SteeringCharacteristic();
+    let tc = new TxCharacteristic();
+    let rc = new RxCharacteristic(tc);
+    super({
+      uuid: Steering,
+      characteristics: [
+        uc1,
+        uc2,
+        uc3,
+        uc4,
+        sc,
+        rc,
+        tc
+      ]
+    });
+    
+    this.uc1 = uc1;
+    this.uc2 = uc2;
+    this.uc3 = uc3;
+    this.uc4 = uc4;
+    this.sc = sc;
+    this.rc = rc;
+    this.tc = tc;
+  }
+
+  notify(event) {
+    this.sc.notify(event);
+    return this.RESULT_SUCCESS;
+  };
+}
+
+module.exports = SteeringService;

--- a/node/steering-service/tx-characteristic.js
+++ b/node/steering-service/tx-characteristic.js
@@ -1,0 +1,46 @@
+
+const bleno = require('bleno');
+const debug = require('debug');
+const trace = debug('fortiusant:tx');
+
+const CharacteristicUserDescription = '2901';
+const TxFeature = '347b0032-7635-408b-8918-8ff3949ce592';
+
+class TxCharacteristic extends bleno.Characteristic {
+  constructor() {
+    trace('[TxCharacteristic] constructor');
+    super({
+      uuid: TxFeature,
+      properties: ['indicate'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Tx'
+        })
+      ],
+    });
+
+    this.indicate = null;
+  }
+
+  onSubscribe(maxValueSize, updateValueCallback) {
+    trace('[TxCharacteristic] onSubscribe');
+    this.indicate = updateValueCallback;
+
+    let buffer = new Buffer.alloc(4);
+    buffer.writeUInt16BE(0x0310, 0);
+    buffer.writeUInt16BE(0x4a89, 2);
+
+    this.indicate(buffer);
+
+    return this.RESULT_SUCCESS;
+  };
+
+  onUnsubscribe() {
+    trace('[TxCharacteristic] onUnsubscribe');
+    this.indicate = null;
+    return this.RESULT_UNLIKELY_ERROR;
+  };
+}
+
+module.exports = TxCharacteristic;

--- a/node/steering-service/unknown-characteristic-1.js
+++ b/node/steering-service/unknown-characteristic-1.js
@@ -1,0 +1,30 @@
+
+const bleno = require('bleno');
+const debug = require('debug');
+const trace = debug('fortiusant:uc1');
+
+const CharacteristicUserDescription = '2901';
+const UnknownFeature1 = '347b0012-7635-408b-8918-8ff3949ce592';
+
+class UnknownCharacteristic1 extends  bleno.Characteristic {
+  constructor() {
+    trace('[UnknownCharacteristic1] constructor');
+    super({
+      uuid: UnknownFeature1,
+      properties: ['write'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Unknown 1'
+        })
+      ],
+    });
+  }
+
+  onWriteRequest(data, offset, withoutResponse, callback) {
+    trace('[UnknownCharacteristic1] onWriteRequest (' + data + ')');
+    callback(this.RESULT_SUCCESS);
+  }
+}
+
+module.exports = UnknownCharacteristic1;

--- a/node/steering-service/unknown-characteristic-2.js
+++ b/node/steering-service/unknown-characteristic-2.js
@@ -1,0 +1,32 @@
+
+const bleno = require('bleno');
+const debug = require('debug');
+const trace = debug('fortiusant:uc2');
+
+const CharacteristicUserDescription = '2901';
+const UnknownFeature2 = '347b0013-7635-408b-8918-8ff3949ce592';
+
+class UnknownCharacteristic2 extends  bleno.Characteristic {
+  constructor() {
+    trace('[UnknownCharacteristic2] constructor');
+    super({
+      uuid: UnknownFeature2,
+      properties: ['read'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Unknown 2'
+        })
+      ],
+    });
+  }
+
+  onReadRequest(offset, callback) {
+    trace('[UnknownCharacteristic2] onReadRequest');
+    let buffer = new Buffer.alloc(1);
+    buffer.writeUInt8(0xff);
+    callback(this.RESULT_SUCCESS, buffer);
+  }
+}
+
+module.exports = UnknownCharacteristic2;

--- a/node/steering-service/unknown-characteristic-3.js
+++ b/node/steering-service/unknown-characteristic-3.js
@@ -1,0 +1,39 @@
+
+const bleno = require('bleno');
+const debug = require('debug');
+const trace = debug('fortiusant:uc3');
+
+const CharacteristicUserDescription = '2901';
+const UnknownFeature3 = '347b0014-7635-408b-8918-8ff3949ce592';
+
+class UnknownCharacteristic3 extends  bleno.Characteristic {
+  constructor() {
+    trace('[UnknownCharacteristic3] constructor');
+    super({
+      uuid: UnknownFeature3,
+      properties: ['notify'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Unknown 3'
+        })
+      ],
+    });
+
+    this.updateValueCallback = null;
+  }
+
+  onSubscribe(maxValueSize, updateValueCallback) {
+    trace('[UnknownCharacteristic3] onSubscribe');
+    this.updateValueCallback = updateValueCallback;
+    return this.RESULT_SUCCESS;
+  };
+
+  onUnsubscribe() {
+    trace('[UnknownCharacteristic3] onUnsubscribe');
+    this.updateValueCallback = null;
+    return this.RESULT_UNLIKELY_ERROR;
+  };
+}
+
+module.exports = UnknownCharacteristic3;

--- a/node/steering-service/unknown-characteristic-4.js
+++ b/node/steering-service/unknown-characteristic-4.js
@@ -1,0 +1,32 @@
+
+const bleno = require('bleno');
+const debug = require('debug');
+const trace = debug('fortiusant:uc4');
+
+const CharacteristicUserDescription = '2901';
+const UnknownFeature4 = '347b0019-7635-408b-8918-8ff3949ce592';
+
+class UnknownCharacteristic4 extends bleno.Characteristic {
+  constructor() {
+    trace('[UnknownCharacteristic4] constructor');
+    super({
+      uuid: UnknownFeature4,
+      properties: ['read'],
+      descriptors: [
+        new bleno.Descriptor({
+          uuid: CharacteristicUserDescription,
+          value: 'Unknown 4'
+        })
+      ],
+    });
+  }
+
+  onReadRequest(offset, callback) {
+    trace('[UnknownCharacteristic4] onReadRequest');
+    let buffer = new Buffer.alloc(1);
+    buffer.writeUInt8(0xff);
+    callback(this.RESULT_SUCCESS, buffer);
+  }
+}
+
+module.exports = UnknownCharacteristic4;

--- a/node/virtual-trainer.js
+++ b/node/virtual-trainer.js
@@ -7,7 +7,7 @@ const HeartRateService = require('./heart-rate-service/heart-rate-service');
 const SteeringService = require('./steering-service/steering-service');
 
 class VirtualTrainer extends events {
-  constructor(steerinEnabled) {
+  constructor(steeringEnabled) {
     debug('[VirtualTrainer] constructor');
     super();
 
@@ -19,7 +19,7 @@ class VirtualTrainer extends events {
     this.hrs = new HeartRateService();
     this.ss = new SteeringService();
     this.stopTimer = null;
-    this.steerinEnabled = steerinEnabled;
+    this.steeringEnabled = steeringEnabled;
     
     bleno.on('stateChange', (state) => {
       debug(`[${this.name}] stateChange: ${state}`);
@@ -30,7 +30,7 @@ class VirtualTrainer extends events {
           this.hrs.uuid
         ]
 
-        if (this.steerinEnabled) {
+        if (this.steeringEnabled) {
           uuids.push(this.ss.uuid)
         }
 
@@ -51,7 +51,7 @@ class VirtualTrainer extends events {
           this.hrs
         ]
 
-        if (this.steerinEnabled) {
+        if (this.steeringEnabled) {
           services.push(this.ss)
         }
 
@@ -103,7 +103,7 @@ class VirtualTrainer extends events {
 
     this.ftms.notify(event);
     this.hrs.notify(event);
-    if (this.steerinEnabled) {
+    if (this.steeringEnabled) {
       this.ss.notify(event);
     }
 

--- a/node/virtual-trainer.js
+++ b/node/virtual-trainer.js
@@ -4,6 +4,7 @@ const debug = require('debug')('fortiusant:vt');
 
 const FitnessMachineService = require('./fitness-machine-service/fitness-machine-service');
 const HeartRateService = require('./heart-rate-service/heart-rate-service');
+const SteeringService = require('./steering-service/steering-service');
 
 class VirtualTrainer extends events {
   constructor() {
@@ -16,6 +17,7 @@ class VirtualTrainer extends events {
     this.messages = [];
     this.ftms = new FitnessMachineService(this.messages);
     this.hrs = new HeartRateService();
+    this.ss = new SteeringService();
     this.stopTimer = null;
     
     bleno.on('stateChange', (state) => {
@@ -24,7 +26,8 @@ class VirtualTrainer extends events {
       if (state === 'poweredOn') {
         bleno.startAdvertising(this.name, [
           this.ftms.uuid,
-          this.hrs.uuid
+          this.hrs.uuid,
+          this.ss.uuid
         ]);
       }
       else {
@@ -39,7 +42,8 @@ class VirtualTrainer extends events {
       if (!error) {
         bleno.setServices([
           this.ftms,
-          this.hrs
+          this.hrs,
+          this.ss
         ],
         (error) => {
           debug(`[${this.name}] setServices: ${(error ? 'error ' + error : 'success')}`);
@@ -88,6 +92,7 @@ class VirtualTrainer extends events {
 
     this.ftms.notify(event);
     this.hrs.notify(event);
+    this.ss.notify(event);
 
     if (!('stop' in event)) {
       this.stopTimer = setTimeout(() => {

--- a/pythoncode/FortiusAntBody.py
+++ b/pythoncode/FortiusAntBody.py
@@ -1015,7 +1015,7 @@ def Tacx2DongleSub(self, Restart):
                 if clv.ble:
                     bleCTP.SetAthleteData(HeartRate)
                     bleCTP.SetTrainerData(TacxTrainer.SpeedKmh, \
-                                    TacxTrainer.Cadence, TacxTrainer.CurrentPower)
+                                    TacxTrainer.Cadence, TacxTrainer.CurrentPower, 5)
                     if bleCTP.Refresh():
                         if bleCTP.TargetMode == mode_Power:
                             TargetPowerTime = time.time()

--- a/pythoncode/FortiusAntBody.py
+++ b/pythoncode/FortiusAntBody.py
@@ -535,6 +535,9 @@ def Axis2Angle(raw_axis, calib_right, calib_middle):
         if abs(angle) < 7:
             angle = 0.0
 
+        # Limit steering angle from -45 to 45 degrees in case we have an invalid reading
+        angle = max(min(45, angle), -45)
+
     return angle
 
 # ------------------------------------------------------------------------------

--- a/pythoncode/FortiusAntCommand.py
+++ b/pythoncode/FortiusAntCommand.py
@@ -142,6 +142,7 @@ class CommandLineVariables(object):
         parser.add_argument   ('-A','--PedalStrokeAnalysis', help='Pedal Stroke Analysis',                     required=False, action='store_true')
         if UseBluetooth:
            parser.add_argument('-b','--ble',       help='(EXPERIMENTAL) Use Bluetooth LE instead of ANT+',     required=False, action='store_true')
+           parser.add_argument(     '--steering',  help='(EXPERIMENTAL) Use Tacx Steering interface over BLE', required=False, action='store_true')
         parser.add_argument   ('-c','--CalibrateRR',help='calibrate Rolling Resistance for Magnetic Brake',    required=False, default=False)
 #       parser.add_argument   ('-C','--CtrlCommand',help='ANT+ Control Command (#1/#2)',                       required=False, default=False)
         parser.add_argument   ('-C','--CtrlCommand',help=argparse.SUPPRESS,                                    required=False, default=False)
@@ -185,6 +186,7 @@ class CommandLineVariables(object):
         self.autostart              = args.autostart
         if UseBluetooth:
             self.ble                = args.ble
+            self.steering           = args.steering
         if UseGui:
             self.gui                = args.gui
         self.manual                 = args.manual
@@ -202,6 +204,11 @@ class CommandLineVariables(object):
 
         if (self.manual or self.manualGrade) and self.SimulateTrainer:
             logfile.Console("-m/-M and -s both specified, most likely for program test purpose")
+
+        if UseBluetooth:
+            if self.steering and not self.ble:
+                logfile.Console("--steering is specified without -b. Steering requires Bluetooth, forcing it on")
+                self.ble = True
 
         #-----------------------------------------------------------------------
         # Get calibration of Rolling Resistance

--- a/pythoncode/bleDongle.py
+++ b/pythoncode/bleDongle.py
@@ -80,6 +80,10 @@ class clsBleInterface():
                     "node",
                     "server.js"
                 ]
+
+                if clv.steering:
+                    command.append("steering")
+
                 directory = Path.cwd().parent / "node"
                 if debug.on(debug.Ble): logfile.Write("... Popen(%s,%s)" % (directory, command) )
                 try:

--- a/pythoncode/bleDongle.py
+++ b/pythoncode/bleDongle.py
@@ -205,6 +205,7 @@ class clsBleCTP(clsBleInterface):
     CurrentSpeed        = 0
     Cadence             = 0
     CurrentPower        = 0
+    SteeringAngle       = 0
 
     #-----------------------------------------------------------------------
     # CTP data
@@ -221,10 +222,11 @@ class clsBleCTP(clsBleInterface):
     def SetAthleteData(self, HeartRate):
         self.HeartRate      = HeartRate
 
-    def SetTrainerData(self, CurrentSpeed, Cadence, CurrentPower):
+    def SetTrainerData(self, CurrentSpeed, Cadence, CurrentPower, SteeringAngle):
         self.CurrentSpeed   = CurrentSpeed
         self.Cadence        = Cadence
         self.CurrentPower   = CurrentPower
+        self.SteeringAngle  = SteeringAngle
     
     def Refresh(self):
         rtn                 = False
@@ -238,6 +240,7 @@ class clsBleCTP(clsBleInterface):
 
             data['watts']       = self.CurrentPower
             data['cadence']     = self.Cadence
+            data['steering_angle'] = self.SteeringAngle
 
             if self.OK and self.Write(data):
                 if self.Read():
@@ -308,7 +311,7 @@ if __name__ == "__main__":
             try:
                 while True:
                     bleCTP.SetAthleteData(135)
-                    bleCTP.SetTrainerData(34.5, 123, 246)
+                    bleCTP.SetTrainerData(34.5, 123, 246, 0)
 
                     if bleCTP.Refresh():
                         print('Target Mode=%s, Power=%s, Grade=%s' % (bleCTP.TargetMode, bleCTP.TargetPower, bleCTP.TargetGrade) )

--- a/pythoncode/bleDongle.py
+++ b/pythoncode/bleDongle.py
@@ -240,9 +240,15 @@ class clsBleCTP(clsBleInterface):
 
             data['watts']       = self.CurrentPower
             data['cadence']     = self.Cadence
-            data['steering_angle'] = self.SteeringAngle
+            
+            steering = {}
+            steering['steering_angle'] = self.SteeringAngle
 
-            if self.OK and self.Write(data):
+            # We need to send steering information in a separate message, otherwise Zwift will 
+            # not pick it up correctly
+            ok = self.Write(steering)
+
+            if ok and self.OK and self.Write(data):
                 if self.Read():
                     #--------------------------------------------------------
                     # Let's see what we got back

--- a/pythoncode/bleDongle.py
+++ b/pythoncode/bleDongle.py
@@ -41,6 +41,7 @@ class clsBleInterface():
         self.port      = port
         self.interface = None
         self.jsondata  = None
+        self.clv       = clv
         if UseBluetooth and clv.ble:
             self.Message   = ", Bluetooth interface available"
             #---------------------------------------------------------------
@@ -81,7 +82,7 @@ class clsBleInterface():
                     "server.js"
                 ]
 
-                if clv.steering:
+                if self.clv.steering:
                     command.append("steering")
 
                 directory = Path.cwd().parent / "node"


### PR DESCRIPTION
# Steering interface on BLE

This pull request adds initial support for steering in Zwift as described in #152.

Start FortiusANT with the `--steering` option on the command line. FortiusANT will advertise a steering characteristic which Zwift can connect to. When calibrating the rolling resistance, the steering interface is also calibrated, you get hints from the GUI. After you started pedalling, the GUI tells you to steer right, then middle.

Please review my changes and comment where needed.