### PR TITLE
Apply default settings only if no json file is loaded / improve pairing speed

### DIFF
--- a/pythoncode/FortiusAntCommand.py
+++ b/pythoncode/FortiusAntCommand.py
@@ -1,7 +1,8 @@
 #-------------------------------------------------------------------------------
 # Version info
 #-------------------------------------------------------------------------------
-__version__ = "2021-02-01"
+__version__ = "2021-02-12"
+# 2021-02-12    Apply default settings only if no json file loaded
 # 2021-02-01    Standard welcome message changed
 # 2021-01-19    PowerFactor limit changed to 0.5 ... 1.5
 # 2021-01-18    help texts defined as 'constants' to be used for commandline.
@@ -184,7 +185,44 @@ class CommandLineVariables(object):
         # Overwrite from json file if present
         #-----------------------------------------------------------------------
         self.args                   = parser.parse_args()
-        settings.ReadJsonFile(self.args)
+        jsonLoaded = settings.ReadJsonFile(self.args)
+
+        #-----------------------------------------------------------------------
+        # If nothing specified at all, use sensible defaults
+        #-----------------------------------------------------------------------
+        if len(sys.argv) == 1 and not jsonLoaded:
+            pgm = max(sys.argv[0].rfind('/'), sys.argv[0].rfind('\\')) + 1
+            pgm = sys.argv[0][pgm:]
+            print('---------------------------------------------------------------')
+            print('Hello!')
+            print('You have started FortiusANT without command-line parameters.')
+            print(' ')
+            print('Therefore we start with a best-practice setting:')
+            print('     %s -a -g -H0 -A' % pgm)
+            print(' ')
+            print('If you want to start without the graphical user interface:')
+            print('     %s -a' % pgm)
+            print(' ')
+            print('For more info, please refer to the wiki on github.')
+            print('Succes!')
+            self.args.autostart              = True
+            self.args.gui                    = UseGui    # Show gui
+            self.args.hrm                    = 0         # Pair with HRM
+            self.args.PedalStrokeAnalysis    = True      # Show it
+
+        #-----------------------------------------------------------------------
+        # Display welcome message
+        #-----------------------------------------------------------------------
+        print('---------------------------------------------------------------')
+        print('FortiusANT is open source and can be used freely.')
+        print('')
+        print('Just for the fun of knowing where you all are training,')
+        print('put yourself on the FortiusANT map by making yourself known')
+        print('by leaving a message with name/location/trainer on')
+        print('https://github.com/WouterJD/FortiusANT/issues/14')
+        print('')
+        print('or visit the sponsoring page https://github.com/sponsors/WouterJD')
+        print('---------------------------------------------------------------')
 
         #-----------------------------------------------------------------------
         # Booleans; either True or False
@@ -429,38 +467,6 @@ class CommandLineVariables(object):
             logfile.Console("Pedal stroke analysis is not possible in console mode or this Tacx type")
             self.PedalStrokeAnalysis = False
 
-        #-----------------------------------------------------------------------
-        # If nothing specified at all, help the poor windows-users
-        #-----------------------------------------------------------------------
-        if len(sys.argv) == 1:
-            pgm = max(sys.argv[0].rfind('/'), sys.argv[0].rfind('\\')) + 1
-            pgm = sys.argv[0][pgm:]
-            print('---------------------------------------------------------------')
-            print('Hello!')
-            print('You have started FortiusANT without command-line parameters.')
-            print(' ')
-            print('Therefore we start with a best-practice setting:')
-            print('     %s -a -g -H0 -A' % pgm)
-            print(' ')
-            print('If you want to start without the graphical user interface:')
-            print('     %s -a' % pgm)
-            print(' ')
-            print('For more info, please refer to the wiki on github.')
-            print('Succes!')
-            print('---------------------------------------------------------------')
-            print('FortiusANT is open source and can be used freely.')
-            print('')
-            print('Just for the fun of knowing where you all are training,')
-            print('put yourself on the FortiusANT map by making yourself known')
-            print('by leaving a message with name/location/trainer on')
-            print('https://github.com/WouterJD/FortiusANT/issues/14')
-            print('')
-            print('or visit the sponsoring page https://github.com/sponsors/WouterJD')
-            print('---------------------------------------------------------------')
-            self.autostart              = True
-            self.gui                    = UseGui    # Show gui
-            self.hrm                    = 0         # Pair with HRM
-            self.PedalStrokeAnalysis    = True      # Show it
 
     def print(self):
         try:

--- a/pythoncode/settings.py
+++ b/pythoncode/settings.py
@@ -1,7 +1,8 @@
 #-------------------------------------------------------------------------------
 # Version info
 #-------------------------------------------------------------------------------
-__version__ = "2021-01-19"
+__version__ = "2021-02-12"
+# 2021-02-21    Return load result from ReadJsonFile
 # 2021-01-19    PowerFactor limit changed to 0.5 ... 1.5 (50 ... 150)
 # 2021-01-18    help texts defined as 'constants' to be used for commandline.
 #               texts in Json file different from variable name
@@ -108,12 +109,15 @@ def JsonFileExists():
 #               
 # Output:       args, data
 #
-# Returns:      None
+# Returns:      loaded successfully (bool)
 # ------------------------------------------------------------------------------
 def ReadJsonFile (args):
     global data
     if debug.on(debug.Function):
         logfile.Write ("ReadJsonFile () ...")
+
+    jsonLoaded = False
+
     # --------------------------------------------------------------------------
     # Open json file
     # --------------------------------------------------------------------------
@@ -237,19 +241,24 @@ def ReadJsonFile (args):
                     args.Runoff = False
                 else:
                     args.Runoff = "%s/%s/%s/%s/%s" % (RunoffMaxSpeed, RunoffDip, RunoffMinSpeed, RunoffTime, RunoffPower)
+
+            jsonLoaded = True
+
         # ----------------------------------------------------------------------
         # Close json file
         # ----------------------------------------------------------------------
         if debug.on(debug.Function):
             logfile.Write   ("... completed")
 
-        jsonFile.close
+        jsonFile.close()
 
     # --------------------------------------------------------------------------
     # Done
     # --------------------------------------------------------------------------
     if debug.on(debug.Function):
         logfile.Write ("... completed")
+
+    return jsonLoaded
 
 if constants.UseGui:
     # ------------------------------------------------------------------------------
@@ -371,7 +380,7 @@ if constants.UseGui:
             logfile.Console ("Json file cannot be written: " + JsonFileName())
         else:
             json.dump(data, jsonFile, sort_keys=True, indent=4)
-            jsonFile.close
+            jsonFile.close()
 
         if debug.on(debug.Function):
             logfile.Write ("... completed")


### PR DESCRIPTION
- Only apply `-a -g -H0 -A` if no CLI arguments are given _and_ no json file was loaded
- Always show the lower part of the welcome message, even when options are given (I thought this made sense; if you don't like it I will revert)
- Fixed calls to `close` for the json file (parentheses are required since Python 3, otherwise it does nothing)

I was investigating the pairing delay problem and in the process I realized that the default settings are applied even if a settings file is present. In particular, pedal stroke analysis is always active, even on trainers that don't support it. This appears to interfere with the pairing process (why remains to be investigated).

With the patch, pairing of the Genius or Vortex+HU for me is consistently
- immediate with ANTUSB-m
- < 5s with older ANTUSB2