### PR TITLE
Improve node ble

### DIFF
--- a/node/fitness-machine-service/fitness-machine-control-point-characteristic.js
+++ b/node/fitness-machine-service/fitness-machine-control-point-characteristic.js
@@ -94,6 +94,7 @@ class FitnessMachineControlPointCharacteristic extends  bleno.Characteristic {
         if (this.hasControl) {
           debug('Control reset');
           this.hasControl = false;
+          this.isStarted = false;
           response = this.result(code, Success);
 
           // Notify all connected clients that control has been reset

--- a/node/fitness-machine-service/fitness-machine-control-point-characteristic.js
+++ b/node/fitness-machine-service/fitness-machine-control-point-characteristic.js
@@ -80,14 +80,15 @@ class FitnessMachineControlPointCharacteristic extends  bleno.Characteristic {
       case RequestControl:
         debug('[FitnessMachineControlPointCharacteristic] onWriteRequest: RequestControl');
         if (this.hasControl) {
-          debug('Error: already has control');
-          response = this.result(code, ControlNotPermitted);
+          debug('Warning: already has control');
         }
         else {
-          debug('Given control');
           this.hasControl = true;
-          response = this.result(code, Success);
+          debug('Given control');
         }
+
+        // Requesting control always succeeds
+        response = this.result(code, Success);
         break;
       case Reset:
         debug('[FitnessMachineControlPointCharacteristic] onWriteRequest: Reset');


### PR DESCRIPTION
This PR fixes some small issues causing problems when using Zwift as CTP.

- During the Reset Procedure, the isStarted flag is correctly reset now.
- Zwift tries to take control using the Request Control Procedure multiple times, even if it already has control. This was not working in our implementation as control could only be taken once. Now every call to request control will succeed.