### PR TITLE
Upgrade to requests 2.30.0 and urllib3 2.0.2

### DIFF
--- a/badge/requirements.txt
+++ b/badge/requirements.txt
@@ -12,9 +12,9 @@ Jinja2==2.11.3
 MarkupSafe==1.1.1
 python-dateutil==2.8.1
 pytz==2020.4
-requests==2.25.1
+requests==2.30.0
 six==1.15.0
 stravalib==0.10.2
 units==0.7
-urllib3==1.26.5
+urllib3==2.0.2
 Werkzeug==2.2.3


### PR DESCRIPTION
Hello, urllib3 maintainer here :wave:

To upgrade to the next release version of urllib3, requests need to be upgraded too, which is something that dependabot does not handle well, see https://github.com/slaclau/FortiusANT/pull/28 for an example.