### PR TITLE
Overlay window with gearing info

### DIFF
--- a/pythoncode/FortiusAntGui.py
+++ b/pythoncode/FortiusAntGui.py
@@ -1504,8 +1504,10 @@ class frmFortiusAntGui(wx.Frame):
         state = event.GetEventObject().GetValue() 
         if state == True: 
             self.child.Show()
+            self.btnOverlay.SetToolTip ("Hide Overlay")
         else: 
             self.child.Hide()
+            self.btnOverlay.SetToolTip ("Show Overlay")
 
             
 


### PR DESCRIPTION
I added a small overlay window with the gearing.
The window is always-on-top and semitransparent.
You can overlay it to the CTP to keep track of your virtual gearing.


(I also changed the scale on the power display, but this can be ignored, that's just for me)